### PR TITLE
Add Summary-level Rouge-L for English and Japanese

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,15 +2,16 @@ plac>=0.9.6
 sacrebleu>=1.3.2
 # For Test
 pytest==4.4.2
-codecov==2.0.15
-pytest-cov==2.7.1
+codecov
+pytest-cov
 beautifulsoup4>=4.7.1
 -e git+https://github.com/tagucci/pythonrouge.git#egg=pythonrouge
 -e git+https://github.com/bdusell/rougescore.git#egg=rougescore
+rouge-score
 # Basic Element
 spacy>=2.0.0,<3.0.0
 # For Chinese
-jieba>=0.39
-pyhanlp>=0.1.45
+# jieba>=0.39
+# pyhanlp>=0.1.45
 # For Japanese
 janome>=0.3.9

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,8 +2,8 @@ plac>=0.9.6
 sacrebleu>=1.3.2
 # For Test
 pytest==4.4.2
-codecov
-pytest-cov
+codecov==2.0.15
+pytest-cov==2.7.1
 beautifulsoup4>=4.7.1
 -e git+https://github.com/tagucci/pythonrouge.git#egg=pythonrouge
 -e git+https://github.com/bdusell/rougescore.git#egg=rougescore
@@ -11,7 +11,7 @@ rouge-score
 # Basic Element
 spacy>=2.0.0,<3.0.0
 # For Chinese
-# jieba>=0.39
-# pyhanlp>=0.1.45
+jieba>=0.39
+pyhanlp>=0.1.45
 # For Japanese
 janome>=0.3.9

--- a/setup.py
+++ b/setup.py
@@ -46,4 +46,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.6"
     ],
+    extras_require={
+        "ja": ["ja-ginza<6.0"],
+        "en": ["nltk<4.0"]
+    },
 )

--- a/sumeval/metrics/rouge.py
+++ b/sumeval/metrics/rouge.py
@@ -236,7 +236,7 @@ class RougeCalculator():
         f1: float
             f1 score
         """
-        pass
+        raise NotImplementedError()
 
     def get_sentence_tokenizer(self):
         """
@@ -252,7 +252,7 @@ class RougeCalculator():
         -------
         tokenizer: Callable[str, List[str]]
         """
-        pass
+        raise NotImplementedError()
 
     def count_be(self, text, compare_type, is_reference=False):
         bes = self.parse_to_be(text, is_reference)

--- a/sumeval/metrics/rouge.py
+++ b/sumeval/metrics/rouge.py
@@ -7,11 +7,13 @@ class RougeCalculator():
 
     def __init__(self,
                  stopwords=True, stemming=False,
-                 word_limit=-1, length_limit=-1, lang="en"):
+                 word_limit=-1, length_limit=-1, lang="en",
+                 split_summaries=False):
         self.stemming = stemming
         self.stopwords = stopwords
         self.word_limit = word_limit
         self.length_limit = length_limit
+        self.split_summaries = split_summaries
         if isinstance(lang, str):
             self.lang = lang
             self._lang = get_lang(lang)
@@ -181,7 +183,7 @@ class RougeCalculator():
 
     def rouge_l(self, summary, references, alpha=0.5):
         """
-        Calculate ROUGE-L score.
+        Calculate Sentence-Level ROUGE-L score.
 
         Parameters
         ----------
@@ -193,7 +195,7 @@ class RougeCalculator():
             alpha -> 0: recall is more important
             alpha -> 1: precision is more important
             F = 1/(alpha * (1/P) + (1 - alpha) * (1/R))
-        
+
         Returns
         -------
         f1: float
@@ -210,6 +212,47 @@ class RougeCalculator():
         count_for_prec = len(_refs) * len(_summary)
         f1 = self._calc_f1(matches, count_for_recall, count_for_prec, alpha)
         return f1
+
+    def rouge_l_summary(self, summary, references, sentence_tokenizer=None, alpha=0.5):
+        """
+        Calculate Summary-Level ROUGE-L score.
+
+        Parameters
+        ----------
+        summary: str
+            summary text
+        references: str or str[]
+            reference or references to evaluate summary
+        alpha: float (0~1)
+            alpha -> 0: recall is more important
+            alpha -> 1: precision is more important
+            F = 1/(alpha * (1/P) + (1 - alpha) * (1/R))
+        sentence_tokenizer: Optional[Callable[str, List[str]]]
+            sentence tokenizer. If None, use default tokenizer.
+            As for default, see get_sentence_tokenizer().
+
+        Returns
+        -------
+        f1: float
+            f1 score
+        """
+        pass
+
+    def get_sentence_tokenizer(self):
+        """
+        Get default sentence tokenizer.
+
+        The sentence tokenizer is decided by split_summaries and language.
+        If split_summaries is True, use the language specific tokenizer.
+        If English, use nltk.sent_tokenize.
+        If Japanese, use bunkai.
+        If split_summaries is False, use the tokenizer which split text by newline.
+
+        Returns
+        -------
+        tokenizer: Callable[str, List[str]]
+        """
+        pass
 
     def count_be(self, text, compare_type, is_reference=False):
         bes = self.parse_to_be(text, is_reference)
@@ -238,7 +281,7 @@ class RougeCalculator():
             alpha -> 0: recall is more important
             alpha -> 1: precision is more important
             F = 1/(alpha * (1/P) + (1 - alpha) * (1/R))
-        
+
         Returns
         -------
         f1: float

--- a/sumeval/metrics/rouge.py
+++ b/sumeval/metrics/rouge.py
@@ -390,7 +390,7 @@ def _union_lcs(ref, summary):
 def _lcs_idx(ref, summ):
     """Retrun LCS token index between a reference sentence and a summary sentence."""
     table = _lcs_table(ref, summ)
-    return _backtrack(table, ref, sum)
+    return _backtrack(table, ref, summ)
 
 
 def _lcs_table(ref, summ):
@@ -407,6 +407,7 @@ def _lcs_table(ref, summ):
     return table
 
 
+
 def _backtrack(table, ref, summ):
     """Backtrack LCS table."""
     i = len(ref)
@@ -417,8 +418,8 @@ def _backtrack(table, ref, summ):
             idx.insert(0, i - 1)
             i -= 1
             j -= 1
-        elif table[i - 1][j] > table[i][j - 1]:
-            i -= 1
-        else:
+        elif table[i][j - 1] > table[i - 1][j]:
             j -= 1
+        else:
+            i -= 1
     return idx

--- a/tests/test_rouge.py
+++ b/tests/test_rouge.py
@@ -3,6 +3,7 @@ import json
 import sys
 import unittest
 from rougescore import rouge_n, rouge_l
+from rouge_score.rouge_scorer import RougeScorer
 from pythonrouge.pythonrouge import Pythonrouge
 from sumeval.metrics.rouge import RougeCalculator
 
@@ -131,6 +132,32 @@ class TestRouge(unittest.TestCase):
                 v = rouge.rouge_l(s, references)
                 self.assertLess(abs(b2_v - v), 1e-5)
                 self.assertLess(abs(b1_v["ROUGE-L-F"] - v), 1e-5)
+
+    def test_summary_rouge_l(self):
+        data = self.load_test_data()
+        rouge = RougeCalculator(stopwords=True)
+        gl_baseline = RougeScorer(["rougeLsum"], use_stemmer=False)
+        for eval_id in data:
+            summaries = data[eval_id]["summaries"]
+            references = data[eval_id]["references"]
+            baseline = Pythonrouge(
+                        summary_file_exist=False,
+                        summary=[summaries],
+                        reference=[[references]],
+                        n_gram=1, recall_only=False, ROUGE_L=True,
+                        length_limit=True, length=50,
+                        stemming=False, stopwords=True)
+            pythonrouge_score = baseline.calc_score()
+
+            gl_summaries = "\n".join(summaries)
+            gl_references = "\n".join(references)
+            gl_score = gl_baseline.score(gl_references, gl_summaries)
+
+            sentence_tokenizer = lambda x: x.split("\n") # noqa
+            rouge_l_score = rouge.rouge_l_summary(gl_summaries, gl_references, sentence_tokenizer)
+
+            self.assertLess(abs(gl_score["rougeLsum"] - rouge_l_score), 1e-5)
+            self.assertLess(abs(pythonrouge_score["ROUGE-L-F"] - rouge_l_score), 1e-5)
 
 
 if __name__ == "__main__":

--- a/tests/test_rouge.py
+++ b/tests/test_rouge.py
@@ -135,7 +135,7 @@ class TestRouge(unittest.TestCase):
 
     def test_summary_rouge_l(self):
         data = self.load_test_data()
-        rouge = RougeCalculator(stopwords=True)
+        rouge = RougeCalculator(stopwords=False)
         gl_baseline = RougeScorer(["rougeLsum"], use_stemmer=False)
         for eval_id in data:
             summaries = data[eval_id]["summaries"]
@@ -145,8 +145,8 @@ class TestRouge(unittest.TestCase):
                         summary=[summaries],
                         reference=[[references]],
                         n_gram=1, recall_only=False, ROUGE_L=True,
-                        length_limit=True, length=50,
-                        stemming=False, stopwords=True)
+                        length_limit=False,
+                        stemming=False, stopwords=False)
             pythonrouge_score = baseline.calc_score()
 
             gl_summaries = "\n".join(summaries)
@@ -156,7 +156,7 @@ class TestRouge(unittest.TestCase):
             sentence_tokenizer = lambda x: x.split("\n") # noqa
             rouge_l_score = rouge.rouge_l_summary(gl_summaries, gl_references, sentence_tokenizer)
 
-            self.assertLess(abs(gl_score["rougeLsum"] - rouge_l_score), 1e-5)
+            self.assertLess(abs(gl_score["rougeLsum"].fmeasure - rouge_l_score), 1e-5)
             self.assertLess(abs(pythonrouge_score["ROUGE-L-F"] - rouge_l_score), 1e-5)
 
 

--- a/tests/test_rouge_ja.py
+++ b/tests/test_rouge_ja.py
@@ -1,7 +1,9 @@
 import os
 import json
 import unittest
+from collections import defaultdict
 from rougescore import rouge_n
+from pythonrouge.pythonrouge import Pythonrouge
 from sumeval.metrics.rouge import RougeCalculator
 
 
@@ -57,10 +59,38 @@ class TestRougeJA(unittest.TestCase):
             for n in [1, 2]:
                 for s in summaries:
                     v = rouge.rouge_n(s, references, n)
-                    b_v = rouge_n(split(s), 
+                    b_v = rouge_n(split(s),
                                   [split(r) for r in references],
                                   n, 0.5)
                     self.assertLess(abs(b_v - v), 1e-5)
+
+    def test_summary_rouge_l(self):
+        def word2ids(summary, reference):
+            id_dict = defaultdict(lambda: len(id_dict))
+            summary = [" ".join([str(id_dict[w]) for w in sent.split()]) for sent in summary]
+            reference = [" ".join([str(id_dict[w]) for w in sent.split()]) for sent in reference]
+            return summary, reference
+
+        data = self.load_test_data()
+        rouge = RougeCalculator(stopwords=False, lang="ja")
+        for eval_id in data:
+            summaries = data[eval_id]["summaries"]
+            references = data[eval_id]["references"]
+
+            pythonrouge_summaries, pythonrouge_references = word2ids(pythonrouge_summaries, pythonrouge_references)
+            baseline = Pythonrouge(summary_file_exist=False,
+                                   summary=[pythonrouge_summaries],
+                                   references=[[pythonrouge_references]],
+                                   n_gram=1, recall_only=False, ROUGE_L=True,
+                                   length_limit=True, length=100,
+                                   stemming=False, stopwords=False)
+            pythonrouge_score = baseline.calc_score()
+
+            sumeval_summary = "".join(self._compress(summaries))
+            sumeval_reference = "".join(self._compress(references))
+            rouge_l_score = rouge.rouge_l_summary(sumeval_summary, sumeval_reference)
+
+            self.assertLess(abs(pythonrouge_score["ROUGE-L"] - rouge_l_score), 1e-5)
 
 
 if __name__ == "__main__":

--- a/tests/test_rouge_ja.py
+++ b/tests/test_rouge_ja.py
@@ -73,16 +73,20 @@ class TestRougeJA(unittest.TestCase):
 
         data = self.load_test_data()
         rouge = RougeCalculator(stopwords=False, lang="ja")
+        sentence_tokenizer = rouge.get_sentence_tokenizer()
         for eval_id in data:
             summaries = data[eval_id]["summaries"]
             references = data[eval_id]["references"]
 
-            pythonrouge_summaries, pythonrouge_references = word2ids(summaries, references)
+            pythonrouge_summaries = [" ".join(rouge.tokenize(s)) for s in sentence_tokenizer("".join(summaries))]
+            pythonrouge_references = [" ".join(rouge.tokenize(s)) for s in sentence_tokenizer("".join(references))]
+
+            pythonrouge_summaries, pythonrouge_references = word2ids(pythonrouge_summaries, pythonrouge_references)
             baseline = Pythonrouge(summary_file_exist=False,
                                    summary=[pythonrouge_summaries],
                                    reference=[[pythonrouge_references]],
                                    n_gram=1, recall_only=False, ROUGE_L=True,
-                                   length_limit=True, length=100,
+                                   length_limit=False,
                                    stemming=False, stopwords=False)
             pythonrouge_score = baseline.calc_score()
 
@@ -90,7 +94,7 @@ class TestRougeJA(unittest.TestCase):
             sumeval_reference = "".join(self._compress(references))
             rouge_l_score = rouge.rouge_l_summary(sumeval_summary, sumeval_reference)
 
-            self.assertLess(abs(pythonrouge_score["ROUGE-L"] - rouge_l_score), 1e-5)
+            self.assertLess(abs(pythonrouge_score["ROUGE-L-F"] - rouge_l_score), 1e-5)
 
 
 if __name__ == "__main__":

--- a/tests/test_rouge_ja.py
+++ b/tests/test_rouge_ja.py
@@ -77,10 +77,10 @@ class TestRougeJA(unittest.TestCase):
             summaries = data[eval_id]["summaries"]
             references = data[eval_id]["references"]
 
-            pythonrouge_summaries, pythonrouge_references = word2ids(pythonrouge_summaries, pythonrouge_references)
+            pythonrouge_summaries, pythonrouge_references = word2ids(summaries, references)
             baseline = Pythonrouge(summary_file_exist=False,
                                    summary=[pythonrouge_summaries],
-                                   references=[[pythonrouge_references]],
+                                   reference=[[pythonrouge_references]],
                                    n_gram=1, recall_only=False, ROUGE_L=True,
                                    length_limit=True, length=100,
                                    stemming=False, stopwords=False)


### PR DESCRIPTION
- Add Summary-level Rouge-L for English and Japanese

- Add the `split_summaries` arg to RougeCalculator.
  - If this param is False, sentences are separated by newline.
  - If True, text is segmented into sentences using the language-specific sentence tokenizer.

- Summary-level Rouge-L implementations is following Google's rougeLsum.

- Add test for English and Japanese Summary-level Rouge-L.
  - In English, comparing to Google's rouge and pythonrouge.
  - In Japanese, comparing to pythonrouge.
